### PR TITLE
Update models for Rust agent

### DIFF
--- a/agents/rust/src/entity.rs
+++ b/agents/rust/src/entity.rs
@@ -12,6 +12,8 @@ pub enum EntityType {
     Blast,
     #[serde(rename = "bp")]
     BlastPowerUp,
+    #[serde(rename = "fp")]
+    FreezePowerUp,
     #[serde(rename = "m")]
     MetalBlock,
     #[serde(rename = "o")]

--- a/agents/rust/src/unit.rs
+++ b/agents/rust/src/unit.rs
@@ -77,7 +77,7 @@ pub struct Unit {
     /// The agent to which this unit belongs.
     pub agent_id: AgentID,
     /// Latest tick number after which this unit is no longer invulnerable (inclusive).
-    pub invulnerability: u16,
+    pub invulnerable: u16,
 }
 
 impl Unit {
@@ -144,7 +144,7 @@ impl Unit {
             self.inventory = new_state.inventory;
             self.blast_diameter = new_state.blast_diameter;
             self.agent_id = new_state.agent_id;
-            self.invulnerability = new_state.invulnerability;
+            self.invulnerable = new_state.invulnerable;
         } else {
             panic!(
                 "Attempted to update unit '{:?}' with data from unit '{:?}'",


### PR DESCRIPTION


Updates Rust starter agent.

* Use `invulnerability` instead of [`invulnerable`](https://www.gocoder.one/docs/api-reference#unit_stateunit_id). Fixes:
```text
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error("invalid value: integer `9998`, expected u8", line: 0, column: 0)', src/game_connection.rs:55:65
stack backtrace:
   0: rust_begin_unwind
             at ./rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/std/src/panicking.rs:517:5
   1: core::panicking::panic_fmt
             at ./rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/panicking.rs:100:14
   2: core::result::unwrap_failed
             at ./rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/result.rs:1616:5
   3: bomberland_starter_kit::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

* Add missing [Freeze Powerup](https://www.gocoder.one/docs/api-reference#entities). Fixes:
```text
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error("invalid value: integer `9998`, expected i32", line: 0, column: 0)', src/game_connection.rs:55:65
stack backtrace:
   0: rust_begin_unwind
             at ./rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/std/src/panicking.rs:517:5
   1: core::panicking::panic_fmt
             at ./rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/panicking.rs:100:14
   2: core::result::unwrap_failed
             at ./rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/result.rs:1616:5
   3: bomberland_starter_kit::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```