### PR TITLE
CI: build engine on every master commit + push to gocoderone namespace

### DIFF
--- a/.github/workflows/build-and-push-engine.yaml
+++ b/.github/workflows/build-and-push-engine.yaml
@@ -6,12 +6,10 @@ name: Build and Push Bomberland Engine
 # image is pushed to Docker Hub only on push to master.
 
 on:
+    # Every merge/commit to master builds and pushes the engine image.
     push:
         branches:
             - master
-        paths:
-            - "engine/**"
-            - ".github/workflows/build-and-push-engine.yaml"
     pull_request:
         branches:
             - master


### PR DESCRIPTION
Removes the `engine/**` path filter on the **push** trigger so every merge/commit to `master` rebuilds and pushes `coderonehq/bomberland-engine` — not only commits that touch the engine.

- `push: master` → builds + pushes on every commit/merge (Docker Hub secrets now configured).
- `pull_request` stays scoped to `engine/**` so unrelated PRs don't run the long engine build.
- Still GitHub-hosted (`ubuntu-latest`); PRs build-only, push only on master.

Merging this PR will itself trigger a master run — the end-to-end Docker Hub push validation (the earlier master run only failed because secrets weren't set yet; all build steps passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)