### PR TITLE
Fix stale engine image references (dead ACR / old pin)

### DIFF
--- a/base-compose.yml
+++ b/base-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
     game-engine:
-        image: gocoderone/bomberland-engine:2477
+        image: gocoderone/bomberland-engine:latest
         volumes:
             - type: "bind"
               source: ./agents/replay.json

--- a/engine/bomberland-ui/src/locales/en.json
+++ b/engine/bomberland-ui/src/locales/en.json
@@ -70,7 +70,7 @@
     "joinWaitlist": "Join waitlist →",
     "keepUpToDate": "To keep up to date on all announcements and giveaways, make sure you join the <1>Discord Group</1>.",
     "lastUpdated": "Last update",
-    "latestImage": "Latest tournament engine image: coderone.azurecr.io/game-server:1663",
+    "latestImage": "Latest tournament engine image: gocoderone/bomberland-engine:latest",
     "leaderboard": "Leaderboard",
     "leaderboardCountdown": "Next matches run in... {{currentTimer}}",
     "learnMore": "Learn more",

--- a/engine/bomberland-ui/src/source-filesystem/docs/1-getting-started/page.md
+++ b/engine/bomberland-ui/src/source-filesystem/docs/1-getting-started/page.md
@@ -36,7 +36,7 @@ It may take a few minutes to run the first time. This will build the game server
 
 Once the game server is running, you should see:
 ```bash
-game-server_1    | [1] 2021-10-28T02:57:47.701Z - Agent [defaultName](b) connected to the server
+game-engine-1    | [1] 2021-10-28T02:57:47.701Z - Agent [defaultName](b) connected to the server
 ```
 
 Since Bomberland is a 2-player environment, the game engine will wait for a second agent to connect.
@@ -72,7 +72,7 @@ If you need help or have any feedback, please reach out on [Discord](https://dis
 Here are some other tasks to try:
 
 - [ ] **Switch agents:** `docker-compose.yml` specifies which agents to connect. Try switching which character you play as, or playing your agent against itself.
-- [ ] **Change environment variables:** Settings such as tick rate, map size, no. of agents can be changed under `docker-compose.yml` > `game-server` > `environment`. See [⚙️ Environment Flags](/docs/api-reference/#%EF%B8%8F-environment-flags) for a full list of available settings.
+- [ ] **Change environment variables:** Settings such as tick rate, map size, no. of agents can be changed under `docker-compose.yml` > `game-engine` > `environment`. See [⚙️ Environment Flags](/docs/api-reference/#%EF%B8%8F-environment-flags) for a full list of available settings.
 - [ ] **Improve the starter agent:** Try building an agent that beats the random agent.
 - [ ] **Make a new submission:** Follow the [Submission Instructions](/docs/submission-instructions).
 

--- a/engine/bomberland-ui/src/source-filesystem/docs/3-api-reference/page.md
+++ b/engine/bomberland-ui/src/source-filesystem/docs/3-api-reference/page.md
@@ -12,7 +12,7 @@ Agents connect to the game server via websockets.
 The provided [starter kits](https://github.com/CoderOneHQ/bomberland) will have this set up for you.
 
 ```bash
-GAME_CONNECTION_STRING=ws://game-server:3000/?role=agent&agentId=agentId&name=python3-agent
+GAME_CONNECTION_STRING=ws://game-engine:3000/?role=agent&agentId=agentId&name=python3-agent
 ```
 
 ### Roles


### PR DESCRIPTION
Cleans up the two stale engine-image references surfaced while migrating CI to Docker Hub.

| File | Before | After |
|---|---|---|
| `engine/bomberland-ui/src/locales/en.json` | `coderone.azurecr.io/game-server:1663` (shut-down Azure ACR) | `gocoderone/bomberland-engine:latest` |
| `base-compose.yml` | `gocoderone/bomberland-engine:2477` (2024 build) | `gocoderone/bomberland-engine:latest` |

`gocoderone/bomberland-engine:latest` is the tag the new GitHub Actions workflow publishes on every master merge, so both now track current builds.

Note: `gocoderone/game-server` is **not** referenced anywhere in this repo — the only `game-server` mentions were this dead-ACR UI string and compose service/hostnames (now `game-engine`).

I used `:latest` (self-updating). If you'd rather pin for reproducibility — e.g. the engine `base-compose` should match a specific tournament build — say the word and I'll pin both to a concrete tag instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)